### PR TITLE
added mustCallSuper annotation to props and pushed dart 3 support.

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -26,6 +26,8 @@ abstract class Equatable {
   /// The list of properties that will be used to determine whether
   /// two instances are equal.
   /// {@endtemplate}
+  @mustBeOverridden
+  @mustCallSuper
   List<Object?> get props;
 
   /// {@template equatable_stringify}

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -12,6 +12,8 @@ import 'equatable_utils.dart';
 @immutable
 mixin EquatableMixin {
   /// {@macro equatable_props}
+  @mustBeOverridden
+  @mustCallSuper
   List<Object?> get props;
 
   /// {@macro equatable_stringify}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/felangel/equatable
 documentation: https://github.com/felangel/equatable
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/test/equatable_config_test.dart
+++ b/test/equatable_config_test.dart
@@ -3,7 +3,7 @@ import 'package:equatable/equatable.dart';
 import 'package:test/test.dart';
 
 class Credentials extends Equatable {
-  const Credentials({
+  Credentials({
     required this.username,
     required this.password,
     this.shouldStringify,
@@ -20,6 +20,7 @@ class Credentials extends Equatable {
   bool? get stringify => shouldStringify;
 }
 
+// ignore: missing_override_of_must_be_overridden
 abstract class EquatableBase with EquatableMixin {}
 
 class CredentialsMixin extends EquatableBase {

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 class NonEquatable {}
 
+// ignore: missing_override_of_must_be_overridden
 abstract class EquatableBase with EquatableMixin {}
 
 class EmptyEquatable extends EquatableBase {
@@ -96,6 +97,9 @@ class ComplexStringify extends ComplexEquatable {
 
   @override
   bool get stringify => true;
+
+  @override
+  List<Object?> get props => super.props;
 }
 
 class ExplicitStringifyFalse extends ComplexEquatable {
@@ -103,7 +107,7 @@ class ExplicitStringifyFalse extends ComplexEquatable {
       : super(name: name, age: age, hairColor: hairColor);
 
   @override
-  List<Object?> get props => [name, age, hairColor];
+  List<Object?> get props => super.props;
 
   @override
   bool get stringify => false;

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -60,6 +60,20 @@ class ComplexEquatable extends Equatable {
   List<Object?> get props => [name, age, hairColor, children];
 }
 
+class ComplexExtEquatable extends ComplexEquatable {
+  const ComplexExtEquatable(
+      {String? name,
+      int? age,
+      Color? hairColor,
+      List<String>? children,
+      this.height})
+      : super(name: name, age: age, hairColor: hairColor, children: children);
+  final int? height;
+
+  @override
+  List<Object?> get props => [...super.props, height];
+}
+
 class EquatableData extends Equatable {
   const EquatableData({required this.key, required this.value});
 
@@ -691,6 +705,62 @@ void main() {
         children: ['Bob'],
       );
       expect(instanceA == instanceB, false);
+    });
+  });
+
+  group('ComplexExtEquatable', () {
+    test('should return false when values only differ in super property', () {
+      final instanceA = ComplexExtEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        height: 23,
+      );
+      final instanceB = ComplexExtEquatable(
+        name: 'Joe',
+        age: 41,
+        hairColor: Color.black,
+        children: ['Bob'],
+        height: 23,
+      );
+
+      expect(instanceA == instanceB, false);
+    });
+    test('should return false when values only differ in extended property',
+        () {
+      final instanceA = ComplexExtEquatable(
+        name: 'Joe',
+        age: 41,
+        hairColor: Color.black,
+        children: ['Bob'],
+        height: 23,
+      );
+      final instanceB = ComplexExtEquatable(
+        name: 'Joe',
+        age: 41,
+        hairColor: Color.black,
+        children: ['Bob'],
+        height: 24,
+      );
+
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return true when values are exactly equal', () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      expect(instanceA == instanceB, true);
     });
   });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO
(only annotations)

## Description
The goal is to get a type annotation whenever you extend a class that extends Equatable or that includes EquatableMixin.

Specifically, although it will compile, it will complain in these scenarios:
<img width="865" alt="image" src="https://github.com/utamori/equatable/assets/3169217/e33a532f-d35b-4b50-acb6-7896366e172a">
 
To fix it simply add props as follows:
<img width="552" alt="image" src="https://github.com/utamori/equatable/assets/3169217/deaf352a-e23a-4074-a424-bf4b2b7a3546">

## Related PRs
No related PRs.

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
See the image above. Basically extend any class that implements `EquatableMixin` or extend any class that extends `Equatable`.

## Impact to Remaining Code Base
This PR will affect:
Nothing. It's just a code annotation.